### PR TITLE
add test to cover new TA::with behavior

### DIFF
--- a/test/built-ins/Array/prototype/toReversed/frozen-this-value.js
+++ b/test/built-ins/Array/prototype/toReversed/frozen-this-value.js
@@ -6,6 +6,7 @@ esid: sec-array.prototype.toReversed
 description: >
   Array.prototype.toReversed works on frozen objects
 features: [change-array-by-copy]
+includes: [compareArray.js]
 ---*/
 
 var arr = Object.freeze([0, 1, 2]);

--- a/test/built-ins/Array/prototype/toSorted/frozen-this-value.js
+++ b/test/built-ins/Array/prototype/toSorted/frozen-this-value.js
@@ -6,6 +6,7 @@ esid: sec-array.prototype.toSorted
 description: >
   Array.prototype.toSorted works on frozen objects
 features: [change-array-by-copy]
+includes: [compareArray.js]
 ---*/
 
 var arr = Object.freeze([2, 0, 1]);

--- a/test/built-ins/TypedArray/prototype/with/early-type-coercion.js
+++ b/test/built-ins/TypedArray/prototype/with/early-type-coercion.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 Igalia. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.with
+description: >
+  %TypedArray%.prototype.with invokes ToNumber before copying
+info: |
+  %TypedArray%.prototype.with ( index, value )
+
+  ...
+  7. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
+  8. Else, set _value_ to ? ToNumber(_value_).
+  ...
+features: [TypedArray, change-array-by-copy]
+includes: [testTypedArray.js, compareArray.js]
+---*/
+
+testWithTypedArrayConstructors(TA => {
+  var arr = new TA([0, 1, 2]);
+
+  var value = {
+    valueOf() {
+      arr[0] = 3;
+      return 4;
+    }
+  };
+
+  assert.compareArray(arr.with(1, value), [3, 4, 2]);
+  assert.compareArray(arr, [3, 1, 2]);
+});


### PR DESCRIPTION
TA::with now converts the value being inserted to a number before starting the loop. To avoid userland code for running during the loop. This new test covers this change.

https://github.com/tc39/proposal-change-array-by-copy/issues/85