### PR TITLE
BigIntTypedArray::with early type coercion tested

### DIFF
--- a/test/built-ins/TypedArray/prototype/with/BigInt/early-type-coercion-bigint.js
+++ b/test/built-ins/TypedArray/prototype/with/BigInt/early-type-coercion-bigint.js
@@ -1,0 +1,31 @@
+// Copyright (C) 2021 Igalia. All rights reserved.
+// This code is governed by the BSD license found in the LICENSE file.
+
+/*---
+esid: sec-%typedarray%.prototype.with
+description: >
+  %TypedArray%.prototype.with invokes ToNumber before copying
+info: |
+  %TypedArray%.prototype.with ( index, value )
+
+  ...
+  7. If _O_.[[ContentType]] is ~BigInt~, set _value_ to ? ToBigInt(_value_).
+  8. Else, set _value_ to ? ToNumber(_value_).
+  ...
+features: [BigInt, TypedArray, change-array-by-copy]
+includes: [testBigIntTypedArray.js, compareArray.js]
+---*/
+
+testWithBigIntTypedArrayConstructors(function(TA) {
+  var arr = new TA([0n, 1n, 2n]);
+
+  var value = {
+    valueOf() {
+      arr[0] = 3n;
+      return 4n;
+    }
+  };
+
+  assert.compareArray(arr.with(1, value), [3n, 4n, 2n]);
+  assert.compareArray(arr, [3n, 1n, 2n]);
+});


### PR DESCRIPTION
https://github.com/nicolo-ribaudo/test262/blob/change-array-by-copy/test/built-ins/TypedArray/prototype/with/early-type-coercion.js but for the BigInt branch of the spec.